### PR TITLE
Adds PointerNil func

### DIFF
--- a/val/pointer_nil.go
+++ b/val/pointer_nil.go
@@ -1,0 +1,11 @@
+package val
+
+// PointerNil behaves similarly to Pointer, except if the value of v is a zeroed value (eg. empty string), it returns nil instead.
+func PointerNil[T comparable](v T) *T {
+	var zeroValue T
+	if zeroValue == v {
+		// zeroed values with PointerNil should therefore return nil
+		return nil
+	}
+	return Pointer(v)
+}

--- a/val/pointer_nil_test.go
+++ b/val/pointer_nil_test.go
@@ -1,0 +1,14 @@
+package val_test
+
+import (
+	"testing"
+
+	"github.com/aidenwallis/go-utils/val"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPointerNil(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, val.PointerNil(""))
+	assert.EqualValues(t, "some string", val.PointerValue(val.PointerNil("some string")))
+}


### PR DESCRIPTION
Adds new `PointerNil` to `val` package. The use case being you can return `nil` if you provide an empty string, a zeroed int, etc.