### PR TITLE
make ternary type parameter any

### DIFF
--- a/utils/ternary.go
+++ b/utils/ternary.go
@@ -1,7 +1,7 @@
 package utils
 
 // Ternary allows you to write ternary expressions in go, if exp is true, then ifCond is returned, else, elseCond is returned.
-func Ternary[T comparable](exp bool, ifCond T, elseCond T) T {
+func Ternary[T any](exp bool, ifCond T, elseCond T) T {
 	if exp {
 		return ifCond
 	}


### PR DESCRIPTION
This doesn't need to be `comparable`, and is limiting how useful this func is. This isn't a breaking change because anything that is `comparable` is also compatible with `any`.