### PR TITLE
Adds slice utils and val.Default()

### DIFF
--- a/utils/index_in_slice.go
+++ b/utils/index_in_slice.go
@@ -1,0 +1,10 @@
+package utils
+
+// IndexInSlice returns whether an index exists within a given slice
+func IndexInSlice[T any](v []T, index int) bool {
+	if index < 0 {
+		// slices cannot be less than 0 in size
+		return false
+	}
+	return len(v) > index
+}

--- a/utils/index_in_slice_test.go
+++ b/utils/index_in_slice_test.go
@@ -1,0 +1,19 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/aidenwallis/go-utils/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIndexInSlice(t *testing.T) {
+	t.Parallel()
+	v := []int{0, 1, 2, 3}
+	assert.False(t, utils.IndexInSlice(v, -1))
+	assert.True(t, utils.IndexInSlice(v, 0))
+	assert.True(t, utils.IndexInSlice(v, 1))
+	assert.True(t, utils.IndexInSlice(v, 2))
+	assert.True(t, utils.IndexInSlice(v, 3))
+	assert.False(t, utils.IndexInSlice(v, 4))
+}

--- a/utils/value_at_index.go
+++ b/utils/value_at_index.go
@@ -1,0 +1,11 @@
+package utils
+
+import "github.com/aidenwallis/go-utils/val"
+
+// ValueAtIndex returns the value at a given index in a slice
+func ValueAtIndex[T any](v []T, index int) (T, bool) {
+	if IndexInSlice(v, index) {
+		return v[index], true
+	}
+	return val.Default[T](), false
+}

--- a/utils/value_at_index_test.go
+++ b/utils/value_at_index_test.go
@@ -1,0 +1,59 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/aidenwallis/go-utils/utils"
+	"github.com/aidenwallis/go-utils/val"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValueAtIndex(t *testing.T) {
+	t.Parallel()
+
+	// handles normal slices
+	{
+		v := []int{0, 1, 2}
+
+		{
+			r, ok := utils.ValueAtIndex(v, 0)
+			assert.Equal(t, 0, r)
+			assert.True(t, ok)
+		}
+
+		{
+			r, ok := utils.ValueAtIndex(v, 1)
+			assert.Equal(t, 1, r)
+			assert.True(t, ok)
+		}
+
+		{
+			r, ok := utils.ValueAtIndex(v, 2)
+			assert.Equal(t, 2, r)
+			assert.True(t, ok)
+		}
+
+		{
+			r, ok := utils.ValueAtIndex(v, 3)
+			assert.Equal(t, 0, r)
+			assert.False(t, ok)
+		}
+	}
+
+	// handles pointer slices
+	{
+		v := []*int{val.Pointer(0)}
+
+		{
+			r, ok := utils.ValueAtIndex(v, 0)
+			assert.Equal(t, 0, *r)
+			assert.True(t, ok)
+		}
+
+		{
+			r, ok := utils.ValueAtIndex(v, 1)
+			assert.Nil(t, r)
+			assert.False(t, ok)
+		}
+	}
+}

--- a/val/default.go
+++ b/val/default.go
@@ -1,0 +1,7 @@
+package val
+
+// Default returns the default value of any type (if pointer, it is nil).
+func Default[T any]() T {
+	var r T
+	return r
+}

--- a/val/default_test.go
+++ b/val/default_test.go
@@ -1,0 +1,14 @@
+package val_test
+
+import (
+	"testing"
+
+	"github.com/aidenwallis/go-utils/val"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefault(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 0, val.Default[int]())
+	assert.Nil(t, val.Default[*int]())
+}


### PR DESCRIPTION
### utils
* `utils.ValueAtIndex` to fetch the value (or default) value at the index of a given slice. This is panic safe, and will return a `bool` as the second return value to indicate whether the value existed in the slice.
* `utils.IndexInSlice` returns a boolean that indicates whether a value exists at a given index in a slice.

### val
* `val.Default` will return the default zero value for any given type parameter. This is just syntactical sugar on top of doing `var v T`