### PR TITLE
Remove testify

### DIFF
--- a/bitmask/bitmask_test.go
+++ b/bitmask/bitmask_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/aidenwallis/go-utils/bitmask"
-	"github.com/stretchr/testify/assert"
+	"github.com/aidenwallis/go-utils/internal/assert"
 )
 
 func TestBits(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/aidenwallis/go-utils
 
 go 1.18
 
-require golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
+require golang.org/x/exp v0.0.0-20221110155412-d0897a79cd37

--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,4 @@ module github.com/aidenwallis/go-utils
 
 go 1.18
 
-require (
-	github.com/stretchr/testify v1.7.1
-	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
-)
-
-require (
-	github.com/davecgh/go-spew v1.1.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
-)
+require golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,4 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
 golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+golang.org/x/exp v0.0.0-20221110155412-d0897a79cd37 h1:wKMvZzBFHbOCGvF2OmxR5Fqv/jDlkt7slnPz5ejEU8A=
+golang.org/x/exp v0.0.0-20221110155412-d0897a79cd37/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=

--- a/internal/assert/README.md
+++ b/internal/assert/README.md
@@ -1,0 +1,3 @@
+# assert
+
+Barebones assertion library to avoid having to bring another in and adding a dependency to this package.

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -1,0 +1,20 @@
+package assert
+
+import "testing"
+
+// Equal checks if two values are equal else fails the test
+func Equal[T comparable](t *testing.T, expected T, v T) {
+	if expected != v {
+		t.Errorf("expected %#v but got %#v", expected, v)
+	}
+}
+
+// False checks whether v is false
+func False(t *testing.T, v bool) {
+	Equal(t, false, v)
+}
+
+// True checks whether v is true
+func True(t *testing.T, v bool) {
+	Equal(t, true, v)
+}

--- a/localid/generator_test.go
+++ b/localid/generator_test.go
@@ -3,8 +3,8 @@ package localid_test
 import (
 	"testing"
 
+	"github.com/aidenwallis/go-utils/internal/assert"
 	"github.com/aidenwallis/go-utils/localid"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestLocalID(t *testing.T) {

--- a/mathutil/clamp_test.go
+++ b/mathutil/clamp_test.go
@@ -3,8 +3,8 @@ package mathutil_test
 import (
 	"testing"
 
+	"github.com/aidenwallis/go-utils/internal/assert"
 	"github.com/aidenwallis/go-utils/mathutil"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestClamp(t *testing.T) {

--- a/mathutil/max_test.go
+++ b/mathutil/max_test.go
@@ -3,8 +3,8 @@ package mathutil_test
 import (
 	"testing"
 
+	"github.com/aidenwallis/go-utils/internal/assert"
 	"github.com/aidenwallis/go-utils/mathutil"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMax(t *testing.T) {

--- a/mathutil/min_test.go
+++ b/mathutil/min_test.go
@@ -3,8 +3,8 @@ package mathutil_test
 import (
 	"testing"
 
+	"github.com/aidenwallis/go-utils/internal/assert"
 	"github.com/aidenwallis/go-utils/mathutil"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMin(t *testing.T) {

--- a/utils/any_value_in_map_test.go
+++ b/utils/any_value_in_map_test.go
@@ -3,8 +3,8 @@ package utils_test
 import (
 	"testing"
 
+	"github.com/aidenwallis/go-utils/internal/assert"
 	"github.com/aidenwallis/go-utils/utils"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAnyValueInMap(t *testing.T) {

--- a/utils/first_of_test.go
+++ b/utils/first_of_test.go
@@ -3,8 +3,8 @@ package utils_test
 import (
 	"testing"
 
+	"github.com/aidenwallis/go-utils/internal/assert"
 	"github.com/aidenwallis/go-utils/utils"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFirstOf(t *testing.T) {

--- a/utils/index_in_slice_test.go
+++ b/utils/index_in_slice_test.go
@@ -3,8 +3,8 @@ package utils_test
 import (
 	"testing"
 
+	"github.com/aidenwallis/go-utils/internal/assert"
 	"github.com/aidenwallis/go-utils/utils"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestIndexInSlice(t *testing.T) {

--- a/utils/invert_map_test.go
+++ b/utils/invert_map_test.go
@@ -3,8 +3,8 @@ package utils_test
 import (
 	"testing"
 
+	"github.com/aidenwallis/go-utils/internal/assert"
 	"github.com/aidenwallis/go-utils/utils"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestInvertMap(t *testing.T) {
@@ -22,5 +22,7 @@ func TestInvertMap(t *testing.T) {
 		3: "c",
 	}
 
-	assert.EqualValues(t, output, utils.InvertMap(input))
+	for k, v := range input {
+		assert.Equal(t, v, utils.InvertMap(output)[k])
+	}
 }

--- a/utils/reverse_slice_test.go
+++ b/utils/reverse_slice_test.go
@@ -1,16 +1,26 @@
 package utils_test
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/aidenwallis/go-utils/internal/assert"
 	"github.com/aidenwallis/go-utils/utils"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestReverseSlice(t *testing.T) {
 	t.Parallel()
+
+	mustJSON := func(v interface{}) string {
+		bs, err := json.Marshal(v)
+		if err != nil {
+			t.Error("failed to marshal json")
+		}
+		return string(bs)
+	}
+
 	v := []int{1, 2, 3, 4, 5}
-	assert.EqualValues(t, []int{1, 2, 3, 4, 5}, v)
+	assert.Equal(t, mustJSON([]int{1, 2, 3, 4, 5}), mustJSON(v))
 	utils.ReverseSlice(v)
-	assert.EqualValues(t, []int{5, 4, 3, 2, 1}, v)
+	assert.Equal(t, mustJSON([]int{5, 4, 3, 2, 1}), mustJSON(v))
 }

--- a/utils/slice_filter_test.go
+++ b/utils/slice_filter_test.go
@@ -3,8 +3,8 @@ package utils_test
 import (
 	"testing"
 
+	"github.com/aidenwallis/go-utils/internal/assert"
 	"github.com/aidenwallis/go-utils/utils"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSliceFilter(t *testing.T) {
@@ -27,8 +27,11 @@ func TestSliceFilter(t *testing.T) {
 		6,
 	}
 
-	// test that it only returns the even items
-	assert.Equal(t, output, utils.SliceFilter(input, func(i int) bool {
+	v := utils.SliceFilter(input, func(i int) bool {
 		return i%2 == 0
-	}))
+	})
+
+	for i, vv := range v {
+		assert.Equal(t, output[i], vv)
+	}
 }

--- a/utils/slice_map_test.go
+++ b/utils/slice_map_test.go
@@ -3,8 +3,8 @@ package utils_test
 import (
 	"testing"
 
+	"github.com/aidenwallis/go-utils/internal/assert"
 	"github.com/aidenwallis/go-utils/utils"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSliceMap(t *testing.T) {
@@ -37,5 +37,8 @@ func TestSliceMap(t *testing.T) {
 		}{a: v.a, b: v.a + 1}
 	}
 
-	assert.Equal(t, output, utils.SliceMap(input, iterator))
+	for i, v := range utils.SliceMap(input, iterator) {
+		assert.Equal(t, output[i].a, v.a)
+		assert.Equal(t, output[i].b, v.b)
+	}
 }

--- a/utils/ternary_test.go
+++ b/utils/ternary_test.go
@@ -3,8 +3,8 @@ package utils_test
 import (
 	"testing"
 
+	"github.com/aidenwallis/go-utils/internal/assert"
 	"github.com/aidenwallis/go-utils/utils"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestTernary(t *testing.T) {

--- a/utils/unique_slice_test.go
+++ b/utils/unique_slice_test.go
@@ -3,8 +3,8 @@ package utils_test
 import (
 	"testing"
 
+	"github.com/aidenwallis/go-utils/internal/assert"
 	"github.com/aidenwallis/go-utils/utils"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestUniqueSlice(t *testing.T) {
@@ -15,7 +15,10 @@ func TestUniqueSlice(t *testing.T) {
 
 		input := []int{1, 2, 3, 4, 5, 1, 2, 2, 6, 6}
 		output := []int{1, 2, 3, 4, 5, 6}
-		assert.Equal(t, output, utils.UniqueSlice(input))
+		v := utils.UniqueSlice(input)
+		for i, vv := range v {
+			assert.Equal(t, output[i], vv)
+		}
 	})
 
 	t.Run("strings", func(t *testing.T) {
@@ -23,6 +26,9 @@ func TestUniqueSlice(t *testing.T) {
 
 		input := []string{"a", "b", "A", "b", "C", "d", "E"}
 		output := []string{"a", "b", "A", "C", "d", "E"}
-		assert.Equal(t, output, utils.UniqueSlice(input))
+		v := utils.UniqueSlice(input)
+		for i, vv := range v {
+			assert.Equal(t, output[i], vv)
+		}
 	})
 }

--- a/utils/value_at_index_test.go
+++ b/utils/value_at_index_test.go
@@ -3,9 +3,9 @@ package utils_test
 import (
 	"testing"
 
+	"github.com/aidenwallis/go-utils/internal/assert"
 	"github.com/aidenwallis/go-utils/utils"
 	"github.com/aidenwallis/go-utils/val"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestValueAtIndex(t *testing.T) {
@@ -52,7 +52,7 @@ func TestValueAtIndex(t *testing.T) {
 
 		{
 			r, ok := utils.ValueAtIndex(v, 1)
-			assert.Nil(t, r)
+			assert.Equal(t, nil, r)
 			assert.False(t, ok)
 		}
 	}

--- a/val/default_test.go
+++ b/val/default_test.go
@@ -3,12 +3,12 @@ package val_test
 import (
 	"testing"
 
+	"github.com/aidenwallis/go-utils/internal/assert"
 	"github.com/aidenwallis/go-utils/val"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDefault(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, 0, val.Default[int]())
-	assert.Nil(t, val.Default[*int]())
+	assert.Equal(t, nil, val.Default[*int]())
 }

--- a/val/pointer_nil_test.go
+++ b/val/pointer_nil_test.go
@@ -3,12 +3,12 @@ package val_test
 import (
 	"testing"
 
+	"github.com/aidenwallis/go-utils/internal/assert"
 	"github.com/aidenwallis/go-utils/val"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestPointerNil(t *testing.T) {
 	t.Parallel()
-	assert.Nil(t, val.PointerNil(""))
-	assert.EqualValues(t, "some string", val.PointerValue(val.PointerNil("some string")))
+	assert.Equal(t, nil, val.PointerNil(""))
+	assert.Equal(t, "some string", val.PointerValue(val.PointerNil("some string")))
 }

--- a/val/pointer_test.go
+++ b/val/pointer_test.go
@@ -3,13 +3,12 @@ package val_test
 import (
 	"testing"
 
+	"github.com/aidenwallis/go-utils/internal/assert"
 	"github.com/aidenwallis/go-utils/val"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestPointer(t *testing.T) {
 	t.Parallel()
-
 	value := "string"
-	assert.EqualValues(t, &value, val.Pointer(value))
+	assert.Equal(t, value, val.PointerValue(val.Pointer(value)))
 }

--- a/val/pointer_value_test.go
+++ b/val/pointer_value_test.go
@@ -3,8 +3,8 @@ package val_test
 import (
 	"testing"
 
+	"github.com/aidenwallis/go-utils/internal/assert"
 	"github.com/aidenwallis/go-utils/val"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestPointerValue(t *testing.T) {

--- a/worker/buffered_pool_test.go
+++ b/worker/buffered_pool_test.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/aidenwallis/go-utils/internal/assert"
 	"github.com/aidenwallis/go-utils/worker"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestBufferedPool(t *testing.T) {
@@ -29,7 +29,7 @@ func TestBufferedPool(t *testing.T) {
 
 		pool.WaitAndClose()
 
-		assert.Len(t, outputs, 20)
+		assert.Equal(t, len(outputs), 20)
 	})
 
 	t.Run("try to write to filled queue", func(t *testing.T) {

--- a/worker/unbuffered_pool_test.go
+++ b/worker/unbuffered_pool_test.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/aidenwallis/go-utils/internal/assert"
 	"github.com/aidenwallis/go-utils/worker"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestUnbufferedPool(t *testing.T) {


### PR DESCRIPTION
To reduce the cost of pulling in this package, I've moved all assertions in tests in to a barebones internal `assert` package. It's a lot less fancy than `stretchr/testify`, but as this package is so small, it makes no sense pulling in a heavier dependency.