### PR TITLE
add bitmask.Toggle

### DIFF
--- a/bitmask/bitmask.go
+++ b/bitmask/bitmask.go
@@ -24,3 +24,11 @@ func Remove[T Bit](sum, bit T) T {
 func Has[T Bit](sum, bit T) bool {
 	return (sum & bit) == bit
 }
+
+// Toggle will either add or remove bit from sum depending on whether it currently exists in the bitmask.
+func Toggle[T Bit](sum, bit T) T {
+	if Has(sum, bit) {
+		return Remove(sum, bit)
+	}
+	return Add(sum, bit)
+}

--- a/bitmask/bitmask_test.go
+++ b/bitmask/bitmask_test.go
@@ -20,4 +20,7 @@ func TestBits(t *testing.T) {
 	assert.Equal(t, a, bitmask.Remove(a|b, b))
 	assert.True(t, bitmask.Has(a|b, b))
 	assert.False(t, bitmask.Has(a|b, c))
+
+	assert.Equal(t, a|b, bitmask.Toggle(a, b))
+	assert.Equal(t, b, bitmask.Toggle(a|b, a))
 }


### PR DESCRIPTION
Adds `bitmask.Toggle`, a way to conditionally add/remove a bit to a bitmask based on whether it already exists.