### PR TITLE
only run CI once per commit in PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -40,6 +45,7 @@ jobs:
 
         # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
         # skip-build-cache: true
+
   test:
     name: test | ${{ matrix.go_version }}
     strategy:


### PR DESCRIPTION
Currently CI is running twice per commit in a PR, we only need to run it once, this fixes that.