### PR TITLE
adds `factory.ChainableModifier`

### DIFF
--- a/factory/chainable_modifier.go
+++ b/factory/chainable_modifier.go
@@ -1,0 +1,33 @@
+package factory
+
+// ChainableModifier creates a factory that produces an initial value from initFactory, then lets you change modifiers to modify that value.
+// You're then returned the value once all modifiers have ran over it. This can be particularly useful when building mock data in tests.
+//
+//	func example() {
+//		chain := ChainableModifier(func() *pb.MyRequest {
+//			return &pb.MyRequest{Foo: true, Bar: false}
+//		})
+//
+//		firstRequest := chain() // returns &pb.MyRequest{Foo: true, Bar: false}
+//
+//		secondRequestWithBarTrue := chain(func(v *pb.MyRequest) {
+//			v.Bar = true
+//		}) // returns &pb.MyRequest{Foo: true, Bar: true}
+//
+//		thirdRequestWithValuesSwapped := chain(func(v *pb.MyRequest) {
+//			v.Foo = false
+//		}, func(v *pb.MyRequest) {
+//			v.Bar = true
+//		}) // returns &pb.MyRequest{Foo: false, Bar: true}
+//	}
+func ChainableModifier[T any](initFactory func() T) func(modifiers ...func(T)) T {
+	return func(modifiers ...func(T)) T {
+		out := initFactory()
+
+		for _, fn := range modifiers {
+			fn(out)
+		}
+
+		return out
+	}
+}

--- a/factory/chainable_modifier_test.go
+++ b/factory/chainable_modifier_test.go
@@ -1,0 +1,30 @@
+package factory_test
+
+import (
+	"testing"
+
+	"github.com/aidenwallis/go-utils/factory"
+	"github.com/aidenwallis/go-utils/internal/assert"
+)
+
+func TestChainableModifier(t *testing.T) {
+	t.Parallel()
+
+	type testValue struct {
+		Foo bool
+		Bar bool
+	}
+
+	chain := factory.ChainableModifier(func() *testValue {
+		return &testValue{
+			Foo: true,
+			Bar: false,
+		}
+	})
+
+	out := chain(func(v *testValue) {
+		v.Foo = false
+	})
+	assert.False(t, out.Foo)
+	assert.False(t, out.Bar)
+}


### PR DESCRIPTION
`factory.ChainableModifier` provides an easy way to produce modifier factory funcs that can generate some output based off of an initial state you define.

There's an example in the doc for the function, but this is really useful if you need to test things like validation logic: define your valid input, then use modifiers per test to make the input invalid in some specific way, without rebuilding a struct from scratch each time.

I put some thought into the API, I kind of hate the initial state value requiring a function, but in order to properly support things like pointer values, this is a necessity. It's worth noting this only really works for pointer values too, since not using a pointer will not carry the value to the next modifier. I considered making this API return the new value each time, but that could give the impression that we copy between each modifier, which could lead to unintentional behaviour.

This API works, just use a pointer for values like ints when you put them through the chain, and deref them at the end, if you really need to: though this is only really valuable for things like larger structs.